### PR TITLE
Not sure what this was, removed

### DIFF
--- a/src/app/add-restroom/page.tsx
+++ b/src/app/add-restroom/page.tsx
@@ -133,7 +133,7 @@ export default function AddRestroomPage() {
             </CardContent>
           </Card>
 
-          <Card className={`${document.getElementById("menstrual-products")?.checked ? "" : "opacity-50"}`}>
+          <Card>
             <CardHeader>
               <CardTitle>Menstrual Products Information</CardTitle>
               <CardDescription>Provide details about menstrual product availability</CardDescription>


### PR DESCRIPTION
getElementById doesn't have a checked property? Because of this it defaults to 50% opacity, and I'm not sure why we have this.